### PR TITLE
Add timeline-style journal screen UI

### DIFF
--- a/app/src/main/java/com/example/nambukhwangdan/model/DiaryMapper.kt
+++ b/app/src/main/java/com/example/nambukhwangdan/model/DiaryMapper.kt
@@ -17,3 +17,21 @@ fun Diary.toEntity(): DiaryEntity {
         nickname = this.nickname
     )
 }
+
+fun DiaryEntity.toDiary(): Diary {
+    return Diary(
+        id = this.id,
+        photoUrls = this.photoUrls,
+        content = this.content,
+        analyzedAt = this.analyzedAt,
+        emotion = this.emotion,
+        sticker = this.sticker,
+        date = this.date,
+        sendToFuture = this.sendToFuture,
+        replyToId = this.replyToId,
+        createdAt = this.createdAt,
+        sendTime = this.sendTime,
+        liked = this.liked,
+        nickname = this.nickname
+    )
+}

--- a/app/src/main/java/com/example/nambukhwangdan/screens/journal/journalScreen.kt
+++ b/app/src/main/java/com/example/nambukhwangdan/screens/journal/journalScreen.kt
@@ -31,7 +31,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -40,47 +41,23 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.nambukhwangdan.model.Diary
 import com.example.nambukhwangdan.ui.theme.Background
 import com.example.nambukhwangdan.ui.theme.Primary
 import com.example.nambukhwangdan.ui.theme.Surface
-
-private data class JournalEntry(
-    val dayLabel: String,
-    val detailDate: String,
-    val summary: String,
-    val isFavorite: Boolean
-)
+import com.example.nambukhwangdan.viewmodel.DiaryViewModel
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 @Composable
-fun JournalScreen(onWriteDiary: () -> Unit) {
-    val entries = remember {
-        listOf(
-            JournalEntry(
-                dayLabel = "28 화",
-                detailDate = "2024.10.28 Tue",
-                summary = "오늘의 일기 내용중 일부가 이곳에 뜨는 중입니다.\n오늘의 일기 내용중 일부가 이곳에 뜨는 중입니다.",
-                isFavorite = true
-            ),
-            JournalEntry(
-                dayLabel = "27 월",
-                detailDate = "2024.10.27 Mon",
-                summary = "오늘의 일기 내용중 일부가 이곳에 뜨는 중입니다.",
-                isFavorite = false
-            ),
-            JournalEntry(
-                dayLabel = "26 일",
-                detailDate = "2024.10.26 Sun",
-                summary = "오늘의 일기 내용중 일부가 이곳에 뜨는 중입니다.",
-                isFavorite = false
-            ),
-            JournalEntry(
-                dayLabel = "25 토",
-                detailDate = "2024.10.25 Sat",
-                summary = "오늘의 일기 내용중 일부가 이곳에 뜨는 중입니다.",
-                isFavorite = false
-            )
-        )
-    }
+fun JournalScreen(
+    viewModel: DiaryViewModel,
+    onWriteDiary: () -> Unit
+) {
+    val diaries by viewModel.allDiaries.collectAsState()
 
     Column(
         modifier = Modifier
@@ -92,7 +69,7 @@ fun JournalScreen(onWriteDiary: () -> Unit) {
         Spacer(modifier = Modifier.height(12.dp))
         DateHeader()
         Spacer(modifier = Modifier.height(12.dp))
-        TimelineList(entries = entries)
+        TimelineList(entries = diaries)
     }
 }
 
@@ -139,6 +116,10 @@ private fun HeaderSection(onWriteDiary: () -> Unit) {
 
 @Composable
 private fun DateHeader() {
+    val today = LocalDate.now()
+    val monthFormatter = DateTimeFormatter.ofPattern("MMMM", Locale.KOREAN)
+    val detailFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd EEE", Locale.KOREAN)
+
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -146,15 +127,15 @@ private fun DateHeader() {
     ) {
         Row(verticalAlignment = Alignment.Bottom) {
             Text(
-                text = "10",
+                text = today.dayOfMonth.toString(),
                 fontSize = 48.sp,
                 fontWeight = FontWeight.Bold,
                 color = Color.Black
             )
             Spacer(modifier = Modifier.width(12.dp))
             Column {
-                Text(text = "October", fontSize = 20.sp, fontWeight = FontWeight.SemiBold)
-                Text(text = "2024.10.21 월", color = Color.DarkGray)
+                Text(text = monthFormatter.format(today), fontSize = 20.sp, fontWeight = FontWeight.SemiBold)
+                Text(text = detailFormatter.format(today), color = Color.DarkGray)
             }
         }
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -179,7 +160,7 @@ private fun DateHeader() {
 }
 
 @Composable
-private fun TimelineList(entries: List<JournalEntry>) {
+private fun TimelineList(entries: List<Diary>) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(14.dp)
@@ -226,7 +207,7 @@ private fun TimelineIndicator(isFirst: Boolean, isLast: Boolean) {
 }
 
 @Composable
-private fun JournalCard(entry: JournalEntry) {
+private fun JournalCard(entry: Diary) {
     Card(
         modifier = Modifier
             .fillMaxWidth(),
@@ -241,19 +222,19 @@ private fun JournalCard(entry: JournalEntry) {
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = entry.dayLabel,
+                    text = formatDayLabel(entry.date),
                     fontWeight = FontWeight.SemiBold,
                     color = Color(0xFF6B6B6B)
                 )
                 Icon(
-                    imageVector = if (entry.isFavorite) Icons.Rounded.Favorite else Icons.Outlined.BookmarkBorder,
+                    imageVector = if (entry.liked) Icons.Rounded.Favorite else Icons.Outlined.BookmarkBorder,
                     contentDescription = null,
-                    tint = if (entry.isFavorite) Primary else Color(0xFF6B6B6B)
+                    tint = if (entry.liked) Primary else Color(0xFF6B6B6B)
                 )
             }
             Spacer(modifier = Modifier.height(6.dp))
             Text(
-                text = entry.summary,
+                text = entry.content,
                 color = Color.Black,
                 fontSize = 14.sp,
                 maxLines = 3,
@@ -261,10 +242,29 @@ private fun JournalCard(entry: JournalEntry) {
             )
             Spacer(modifier = Modifier.height(6.dp))
             Text(
-                text = entry.detailDate,
+                text = formatDetailDate(entry.date),
                 color = Color(0xFF8D8D8D),
                 fontSize = 12.sp
             )
         }
     }
+}
+
+private fun formatDayLabel(dateMillis: Long): String {
+    val date = LocalDate.ofInstant(Instant.ofEpochMilli(dateMillis), ZoneId.systemDefault())
+    val dayOfWeek = when (date.dayOfWeek.value) {
+        1 -> "월"
+        2 -> "화"
+        3 -> "수"
+        4 -> "목"
+        5 -> "금"
+        6 -> "토"
+        else -> "일"
+    }
+    return "${date.dayOfMonth} $dayOfWeek"
+}
+
+private fun formatDetailDate(dateMillis: Long): String {
+    val formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd EEE", Locale.KOREAN)
+    return formatter.format(Instant.ofEpochMilli(dateMillis).atZone(ZoneId.systemDefault()))
 }

--- a/app/src/main/java/com/example/nambukhwangdan/screens/journal/journalScreen.kt
+++ b/app/src/main/java/com/example/nambukhwangdan/screens/journal/journalScreen.kt
@@ -1,12 +1,270 @@
 package com.example.nambukhwangdan.screens.journal
 
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.BookmarkBorder
+import androidx.compose.material.icons.outlined.CalendarMonth
+import androidx.compose.material.icons.rounded.Favorite
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.nambukhwangdan.ui.theme.Background
+import com.example.nambukhwangdan.ui.theme.Primary
+import com.example.nambukhwangdan.ui.theme.Surface
+
+private data class JournalEntry(
+    val dayLabel: String,
+    val detailDate: String,
+    val summary: String,
+    val isFavorite: Boolean
+)
 
 @Composable
 fun JournalScreen(onWriteDiary: () -> Unit) {
-    Button(onClick = onWriteDiary) {
-        Text("일기 쓰기")
+    val entries = remember {
+        listOf(
+            JournalEntry(
+                dayLabel = "28 화",
+                detailDate = "2024.10.28 Tue",
+                summary = "오늘의 일기 내용중 일부가 이곳에 뜨는 중입니다.\n오늘의 일기 내용중 일부가 이곳에 뜨는 중입니다.",
+                isFavorite = true
+            ),
+            JournalEntry(
+                dayLabel = "27 월",
+                detailDate = "2024.10.27 Mon",
+                summary = "오늘의 일기 내용중 일부가 이곳에 뜨는 중입니다.",
+                isFavorite = false
+            ),
+            JournalEntry(
+                dayLabel = "26 일",
+                detailDate = "2024.10.26 Sun",
+                summary = "오늘의 일기 내용중 일부가 이곳에 뜨는 중입니다.",
+                isFavorite = false
+            ),
+            JournalEntry(
+                dayLabel = "25 토",
+                detailDate = "2024.10.25 Sat",
+                summary = "오늘의 일기 내용중 일부가 이곳에 뜨는 중입니다.",
+                isFavorite = false
+            )
+        )
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Background)
+            .padding(horizontal = 18.dp, vertical = 12.dp)
+    ) {
+        HeaderSection(onWriteDiary = onWriteDiary)
+        Spacer(modifier = Modifier.height(12.dp))
+        DateHeader()
+        Spacer(modifier = Modifier.height(12.dp))
+        TimelineList(entries = entries)
+    }
+}
+
+@Composable
+private fun HeaderSection(onWriteDiary: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .size(46.dp)
+                    .clip(CircleShape)
+                    .background(Color(0xFFB1D0B1)),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(text = "나", color = Color.White, fontWeight = FontWeight.Bold)
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Column {
+                Text(
+                    text = "일기장",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = Color.Black
+                )
+                Text(
+                    text = "오늘 하루를 기록해보세요",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.DarkGray
+                )
+            }
+        }
+        Button(
+            onClick = onWriteDiary,
+            shape = RoundedCornerShape(16.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = Primary)
+        ) {
+            Text("일기 쓰기", color = Color.White, fontWeight = FontWeight.SemiBold)
+        }
+    }
+}
+
+@Composable
+private fun DateHeader() {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(verticalAlignment = Alignment.Bottom) {
+            Text(
+                text = "10",
+                fontSize = 48.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color.Black
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column {
+                Text(text = "October", fontSize = 20.sp, fontWeight = FontWeight.SemiBold)
+                Text(text = "2024.10.21 월", color = Color.DarkGray)
+            }
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = { /* TODO: 날짜 선택 기능 */ }) {
+                Icon(
+                    imageVector = Icons.Outlined.CalendarMonth,
+                    contentDescription = "달력",
+                    tint = Color.Black
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(Color.White)
+                    .clickable { /* TODO: 정렬 옵션 */ }
+                    .padding(horizontal = 14.dp, vertical = 8.dp)
+            ) {
+                Text(text = "시간순", fontWeight = FontWeight.Medium, color = Color.Black)
+            }
+        }
+    }
+}
+
+@Composable
+private fun TimelineList(entries: List<JournalEntry>) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(14.dp)
+    ) {
+        itemsIndexed(entries) { index, entry ->
+            Row(modifier = Modifier.fillMaxWidth()) {
+                TimelineIndicator(
+                    isFirst = index == 0,
+                    isLast = index == entries.lastIndex
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                JournalCard(entry = entry)
+            }
+        }
+    }
+}
+
+@Composable
+private fun TimelineIndicator(isFirst: Boolean, isLast: Boolean) {
+    Column(
+        modifier = Modifier.width(38.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        if (!isFirst) {
+            Box(
+                modifier = Modifier
+                    .width(2.dp)
+                    .height(16.dp)
+                    .background(Color(0xFFA2C0A2))
+            )
+        }
+        Canvas(modifier = Modifier.size(32.dp)) {
+            drawCircle(color = Color(0xFF8FC48F))
+        }
+        if (!isLast) {
+            Box(
+                modifier = Modifier
+                    .width(2.dp)
+                    .height(48.dp)
+                    .background(Color(0xFFA2C0A2))
+            )
+        }
+    }
+}
+
+@Composable
+private fun JournalCard(entry: JournalEntry) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = Surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = entry.dayLabel,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color(0xFF6B6B6B)
+                )
+                Icon(
+                    imageVector = if (entry.isFavorite) Icons.Rounded.Favorite else Icons.Outlined.BookmarkBorder,
+                    contentDescription = null,
+                    tint = if (entry.isFavorite) Primary else Color(0xFF6B6B6B)
+                )
+            }
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = entry.summary,
+                color = Color.Black,
+                fontSize = 14.sp,
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = entry.detailDate,
+                color = Color(0xFF8D8D8D),
+                fontSize = 12.sp
+            )
+        }
     }
 }

--- a/app/src/main/java/com/example/nambukhwangdan/screens/journal/journalScreen.kt
+++ b/app/src/main/java/com/example/nambukhwangdan/screens/journal/journalScreen.kt
@@ -47,7 +47,6 @@ import com.example.nambukhwangdan.ui.theme.Primary
 import com.example.nambukhwangdan.ui.theme.Surface
 import com.example.nambukhwangdan.viewmodel.DiaryViewModel
 import java.time.Instant
-import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -67,7 +66,7 @@ fun JournalScreen(
     ) {
         HeaderSection(onWriteDiary = onWriteDiary)
         Spacer(modifier = Modifier.height(12.dp))
-        DateHeader()
+        DateHeader(referenceDateMillis = diaries.firstOrNull()?.date)
         Spacer(modifier = Modifier.height(12.dp))
         TimelineList(entries = diaries)
     }
@@ -115,10 +114,12 @@ private fun HeaderSection(onWriteDiary: () -> Unit) {
 }
 
 @Composable
-private fun DateHeader() {
-    val today = LocalDate.now()
+private fun DateHeader(referenceDateMillis: Long?) {
     val monthFormatter = DateTimeFormatter.ofPattern("MMMM", Locale.KOREAN)
     val detailFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd EEE", Locale.KOREAN)
+    val date = Instant.ofEpochMilli(referenceDateMillis ?: System.currentTimeMillis())
+        .atZone(ZoneId.systemDefault())
+        .toLocalDate()
 
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -127,15 +128,15 @@ private fun DateHeader() {
     ) {
         Row(verticalAlignment = Alignment.Bottom) {
             Text(
-                text = today.dayOfMonth.toString(),
+                text = date.dayOfMonth.toString(),
                 fontSize = 48.sp,
                 fontWeight = FontWeight.Bold,
                 color = Color.Black
             )
             Spacer(modifier = Modifier.width(12.dp))
             Column {
-                Text(text = monthFormatter.format(today), fontSize = 20.sp, fontWeight = FontWeight.SemiBold)
-                Text(text = detailFormatter.format(today), color = Color.DarkGray)
+                Text(text = monthFormatter.format(date), fontSize = 20.sp, fontWeight = FontWeight.SemiBold)
+                Text(text = detailFormatter.format(date), color = Color.DarkGray)
             }
         }
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -151,7 +152,7 @@ private fun DateHeader() {
                     .clip(RoundedCornerShape(14.dp))
                     .background(Color.White)
                     .clickable { /* TODO: 정렬 옵션 */ }
-                    .padding(horizontal = 14.dp, vertical = 8.dp)
+                    .padding(horizontal = 14.dp, vertical = 8.dp),
             ) {
                 Text(text = "시간순", fontWeight = FontWeight.Medium, color = Color.Black)
             }
@@ -165,7 +166,7 @@ private fun TimelineList(entries: List<Diary>) {
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(14.dp)
     ) {
-        itemsIndexed(entries) { index, entry ->
+        itemsIndexed(entries.sortedByDescending(Diary::date)) { index, entry ->
             Row(modifier = Modifier.fillMaxWidth()) {
                 TimelineIndicator(
                     isFirst = index == 0,
@@ -222,7 +223,7 @@ private fun JournalCard(entry: Diary) {
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = formatDayLabel(entry.date),
+                    text = entry.dayLabel(),
                     fontWeight = FontWeight.SemiBold,
                     color = Color(0xFF6B6B6B)
                 )
@@ -242,7 +243,7 @@ private fun JournalCard(entry: Diary) {
             )
             Spacer(modifier = Modifier.height(6.dp))
             Text(
-                text = formatDetailDate(entry.date),
+                text = entry.detailLabel(),
                 color = Color(0xFF8D8D8D),
                 fontSize = 12.sp
             )
@@ -250,8 +251,8 @@ private fun JournalCard(entry: Diary) {
     }
 }
 
-private fun formatDayLabel(dateMillis: Long): String {
-    val date = LocalDate.ofInstant(Instant.ofEpochMilli(dateMillis), ZoneId.systemDefault())
+private fun Diary.dayLabel(): String {
+    val date = Instant.ofEpochMilli(date).atZone(ZoneId.systemDefault()).toLocalDate()
     val dayOfWeek = when (date.dayOfWeek.value) {
         1 -> "월"
         2 -> "화"
@@ -264,7 +265,7 @@ private fun formatDayLabel(dateMillis: Long): String {
     return "${date.dayOfMonth} $dayOfWeek"
 }
 
-private fun formatDetailDate(dateMillis: Long): String {
-    val formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd EEE", Locale.KOREAN)
-    return formatter.format(Instant.ofEpochMilli(dateMillis).atZone(ZoneId.systemDefault()))
+private fun Diary.detailLabel(): String {
+    return DateTimeFormatter.ofPattern("yyyy.MM.dd EEE", Locale.KOREAN)
+        .format(Instant.ofEpochMilli(date).atZone(ZoneId.systemDefault()))
 }

--- a/app/src/main/java/com/example/nambukhwangdan/ui/home/MainScreenHost.kt
+++ b/app/src/main/java/com/example/nambukhwangdan/ui/home/MainScreenHost.kt
@@ -51,6 +51,7 @@ fun MainScreenHost(
             // 일기 탭
             composable(Routes.Journal) {
                 JournalScreen(
+                    viewModel = diaryViewModel,
                     onWriteDiary = {
                         appNavController.navigate(Routes.DiaryWrite)   // 👈 이것도 AppNav로 이동
                     }

--- a/app/src/main/java/com/example/nambukhwangdan/viewmodel/DairyViewModel.kt
+++ b/app/src/main/java/com/example/nambukhwangdan/viewmodel/DairyViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavController
 import com.example.nambukhwangdan.data.repository.DiaryRepository
 import com.example.nambukhwangdan.model.Diary
+import com.example.nambukhwangdan.model.toDiary
 import com.example.nambukhwangdan.model.toEntity
 import com.example.nambukhwangdan.navigation.Routes
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,6 +17,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.util.UUID
@@ -152,6 +154,7 @@ class DiaryViewModel @Inject constructor(
     }
     // --- Repository를 사용하는 로직 (기존 두 번째 ViewModel의 내용) ---
     val allDiaries = repo.getAllDiaries()
+        .map { diaries -> diaries.map { it.toDiary() } }
         .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
     fun saveDiary(diary: Diary) {


### PR DESCRIPTION
## Summary
- replace the journal screen with a timeline-style layout matching the provided mock
- add header, date controls, and sample entries with favorite indicator cards

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923ed495b548321b3ffa6d2616df05e)