### PR TITLE
Add expandable diary list UI to journal screen

### DIFF
--- a/app/src/main/java/com/example/nambukhwangdan/screens/journal/journalScreen.kt
+++ b/app/src/main/java/com/example/nambukhwangdan/screens/journal/journalScreen.kt
@@ -1,7 +1,8 @@
 package com.example.nambukhwangdan.screens.journal
 
-import androidx.compose.foundation.Canvas
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,23 +15,23 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.BookmarkBorder
+import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.rounded.Favorite
-import androidx.compose.material.icons.rounded.KeyboardArrowLeft
-import androidx.compose.material.icons.rounded.KeyboardArrowRight
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -47,263 +48,214 @@ import com.example.nambukhwangdan.viewmodel.DiaryViewModel
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
-import java.time.format.TextStyle
-import java.time.YearMonth
 import java.util.Locale
 
 @Composable
 fun JournalScreen(
     viewModel: DiaryViewModel
 ) {
-    val diaries by viewModel.diariesForMonth.collectAsState()
-    val displayMonth by viewModel.displayMonth.collectAsState()
+    val diaries by viewModel.allDiaries.collectAsState()
+    val sortedDiaries = diaries.sortedByDescending { it.createdAt }
 
     Column(
         modifier = Modifier
             .fillMaxSize()
             .background(Background)
-            .padding(horizontal = 18.dp, vertical = 12.dp)
+            .padding(horizontal = 16.dp, vertical = 12.dp)
     ) {
-        HeaderSection()
+        JournalHeader()
         Spacer(modifier = Modifier.height(12.dp))
-        DateHeader(
-            displayMonth = displayMonth,
-            diaryCount = diaries.size,
-            onPreviousMonth = viewModel::moveToPreviousMonth,
-            onNextMonth = viewModel::moveToNextMonth
-        )
+        JournalDateToolbar()
         Spacer(modifier = Modifier.height(12.dp))
-        if (diaries.isEmpty()) {
-            EmptyState(displayMonth)
+
+        if (sortedDiaries.isEmpty()) {
+            EmptyJournalState()
         } else {
-            TimelineList(entries = diaries)
+            DiaryList(diaries = sortedDiaries)
         }
     }
 }
 
 @Composable
-private fun HeaderSection() {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Box(
-                modifier = Modifier
-                    .size(46.dp)
-                    .clip(CircleShape)
-                    .background(Color(0xFFB1D0B1)),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(text = "나", color = Color.White, fontWeight = FontWeight.Bold)
-            }
-            Spacer(modifier = Modifier.width(12.dp))
-            Column {
-                Text(
-                    text = "일기장",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = Color.Black
-                )
-                Text(
-                    text = "오늘 하루를 기록해보세요",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = Color.DarkGray
-                )
-            }
-        }
+private fun JournalHeader() {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = "일기장",
+            style = MaterialTheme.typography.titleMedium,
+            color = Color.Black
+        )
+        Text(
+            text = "오늘 하루를 기록해보세요",
+            style = MaterialTheme.typography.bodySmall,
+            color = Color(0xFF8B8B8B)
+        )
     }
 }
 
 @Composable
-private fun DateHeader(
-    displayMonth: YearMonth,
-    diaryCount: Int,
-    onPreviousMonth: () -> Unit,
-    onNextMonth: () -> Unit
-) {
-    val monthLabelFormatter = DateTimeFormatter.ofPattern("yyyy년 M월", Locale.KOREAN)
-    val rangeFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd (EEE)", Locale.KOREAN)
-    val start = displayMonth.atDay(1)
-    val end = displayMonth.atEndOfMonth()
+private fun JournalDateToolbar() {
+    val today = Instant.now().atZone(ZoneId.systemDefault()).toLocalDate()
+    val formatter = DateTimeFormatter.ofPattern("d MMMM", Locale.ENGLISH)
 
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Column {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                IconButton(onClick = onPreviousMonth) {
-                    Icon(
-                        imageVector = Icons.Rounded.KeyboardArrowLeft,
-                        contentDescription = "이전 달",
-                        tint = Color.Black
-                    )
-                }
-                Text(
-                    text = monthLabelFormatter.format(displayMonth),
-                    fontSize = 24.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = Color.Black
-                )
-                IconButton(onClick = onNextMonth) {
-                    Icon(
-                        imageVector = Icons.Rounded.KeyboardArrowRight,
-                        contentDescription = "다음 달",
-                        tint = Color.Black
-                    )
-                }
-            }
+        Text(
+            text = formatter.format(today),
+            fontSize = 22.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = Color.Black
+        )
+
+        Card(
+            shape = RoundedCornerShape(18.dp),
+            colors = CardDefaults.cardColors(containerColor = Color.White),
+            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        ) {
             Text(
-                text = "${rangeFormatter.format(start)} ~ ${rangeFormatter.format(end)}", 
+                text = "시간순",
+                modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
                 color = Color(0xFF6B6B6B),
-                fontSize = 12.sp
+                fontWeight = FontWeight.Medium
             )
         }
-        Box(
-            modifier = Modifier
-                .clip(RoundedCornerShape(14.dp))
-                .background(Color.White)
-                .padding(horizontal = 14.dp, vertical = 8.dp)
-        ) {
-            Text(text = "${diaryCount}개의 기록", fontWeight = FontWeight.Medium, color = Color.Black)
-        }
     }
 }
 
 @Composable
-private fun TimelineList(entries: List<Diary>) {
+private fun DiaryList(diaries: List<Diary>) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(14.dp)
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        itemsIndexed(entries.sortedByDescending(Diary::date)) { index, entry ->
-            Row(modifier = Modifier.fillMaxWidth()) {
-                TimelineIndicator(
-                    isFirst = index == 0,
-                    isLast = index == entries.lastIndex
-                )
-                Spacer(modifier = Modifier.width(12.dp))
-                JournalCard(entry = entry)
-            }
-        }
-    }
-}
-
-@Composable
-private fun EmptyState(displayMonth: YearMonth) {
-    val monthLabel = displayMonth.month.getDisplayName(TextStyle.FULL, Locale.KOREAN)
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 48.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(text = "${monthLabel}에는 기록이 없어요", color = Color.DarkGray)
-        Text(text = "달력을 넘겨 다른 달의 기록을 확인해 보세요", color = Color.DarkGray, fontSize = 13.sp)
-    }
-}
-
-@Composable
-private fun TimelineIndicator(isFirst: Boolean, isLast: Boolean) {
-    Column(
-        modifier = Modifier.width(38.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        if (!isFirst) {
-            Box(
-                modifier = Modifier
-                    .width(2.dp)
-                    .height(16.dp)
-                    .background(Color(0xFFA2C0A2))
-            )
-        }
-        Canvas(modifier = Modifier.size(32.dp)) {
-            drawCircle(color = Color(0xFF8FC48F))
-        }
-        if (!isLast) {
-            Box(
-                modifier = Modifier
-                    .width(2.dp)
-                    .height(48.dp)
-                    .background(Color(0xFFA2C0A2))
+        items(diaries, key = { it.id }) { diary ->
+            var expanded by rememberSaveable(diary.id) { mutableStateOf(false) }
+            DiaryCard(
+                diary = diary,
+                expanded = expanded,
+                onToggle = { expanded = !expanded }
             )
         }
     }
 }
 
 @Composable
-private fun JournalCard(entry: Diary) {
+private fun DiaryCard(
+    diary: Diary,
+    expanded: Boolean,
+    onToggle: () -> Unit
+) {
     Card(
         modifier = Modifier
-            .fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
+            .fillMaxWidth()
+            .animateContentSize()
+            .clickable { onToggle() },
+        shape = RoundedCornerShape(18.dp),
         colors = CardDefaults.cardColors(containerColor = Surface),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp)
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
             ) {
-                Column {
-                    Text(
-                        text = entry.dayLabel(),
-                        fontWeight = FontWeight.SemiBold,
-                        color = Color(0xFF6B6B6B)
-                    )
-                    Text(
-                        text = entry.detailLabel(),
-                        color = Color(0xFF8D8D8D),
-                        fontSize = 12.sp
-                    )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    DiarySticker(sticker = diary.sticker)
+                    Spacer(modifier = Modifier.width(10.dp))
+                    Column {
+                        Text(
+                            text = diary.createdAt.dayLabel(),
+                            color = Color(0xFF404040),
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        Text(
+                            text = diary.createdAt.fullDateLabel(),
+                            color = Color(0xFF8D8D8D),
+                            fontSize = 12.sp
+                        )
+                    }
                 }
+
                 Icon(
-                    imageVector = if (entry.liked) Icons.Rounded.Favorite else Icons.Outlined.BookmarkBorder,
+                    imageVector = if (diary.liked) Icons.Rounded.Favorite else Icons.Outlined.FavoriteBorder,
                     contentDescription = null,
-                    tint = if (entry.liked) Primary else Color(0xFF6B6B6B)
+                    tint = if (diary.liked) Primary else Color(0xFF8D8D8D)
                 )
             }
-            Spacer(modifier = Modifier.height(6.dp))
+
+            Spacer(modifier = Modifier.height(8.dp))
             Text(
-                text = entry.content,
+                text = diary.content,
                 color = Color.Black,
                 fontSize = 14.sp,
-                maxLines = 2,
+                maxLines = if (expanded) Int.MAX_VALUE else 3,
                 overflow = TextOverflow.Ellipsis
             )
-            Spacer(modifier = Modifier.height(8.dp))
-            entry.sticker?.takeIf { it.isNotBlank() }?.let { sticker ->
+
+            if (!diary.sticker.isNullOrBlank()) {
+                Spacer(modifier = Modifier.height(10.dp))
                 Box(
                     modifier = Modifier
-                        .clip(RoundedCornerShape(12.dp))
-                        .background(Primary.copy(alpha = 0.12f))
-                        .padding(horizontal = 10.dp, vertical = 6.dp)
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(Primary.copy(alpha = 0.1f))
+                        .padding(horizontal = 12.dp, vertical = 8.dp)
                 ) {
-                    Text(text = sticker, color = Primary, fontWeight = FontWeight.Medium, fontSize = 12.sp)
+                    Text(
+                        text = diary.sticker.orEmpty(),
+                        color = Primary,
+                        fontWeight = FontWeight.Medium,
+                        fontSize = 12.sp
+                    )
                 }
             }
         }
     }
 }
 
-private fun Diary.dayLabel(): String {
-    val date = Instant.ofEpochMilli(date).atZone(ZoneId.systemDefault()).toLocalDate()
-    val dayOfWeek = when (date.dayOfWeek.value) {
-        1 -> "월"
-        2 -> "화"
-        3 -> "수"
-        4 -> "목"
-        5 -> "금"
-        6 -> "토"
-        else -> "일"
+@Composable
+private fun DiarySticker(sticker: String?) {
+    Box(
+        modifier = Modifier
+            .size(42.dp)
+            .clip(CircleShape)
+            .background(Primary.copy(alpha = 0.15f)),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = if (sticker.isNullOrBlank()) "💭" else sticker,
+            fontSize = 18.sp
+        )
     }
-    return "${date.dayOfMonth} $dayOfWeek"
 }
 
-private fun Diary.detailLabel(): String {
-    return DateTimeFormatter.ofPattern("yyyy.MM.dd EEE", Locale.KOREAN)
-        .format(Instant.ofEpochMilli(date).atZone(ZoneId.systemDefault()))
+@Composable
+private fun EmptyJournalState() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 64.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(text = "아직 작성된 일기가 없어요", color = Color.DarkGray)
+        Text(
+            text = "하단의 일기 탭에서 새로운 일기를 작성해 보세요",
+            color = Color.DarkGray,
+            fontSize = 13.sp
+        )
+    }
+}
+
+private fun Long.dayLabel(): String {
+    val date = Instant.ofEpochMilli(this).atZone(ZoneId.systemDefault()).toLocalDate()
+    val monthFormatter = DateTimeFormatter.ofPattern("d일 E", Locale.KOREAN)
+    return monthFormatter.format(date)
+}
+
+private fun Long.fullDateLabel(): String {
+    val dateTime = Instant.ofEpochMilli(this).atZone(ZoneId.systemDefault())
+    val formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd (EEE)", Locale.KOREAN)
+    return formatter.format(dateTime)
 }


### PR DESCRIPTION
## Summary
- rebuild the journal screen to show diaries in a lazy column sorted by creation time
- add expandable diary cards that display stickers, liked state, and full content on tap
- include empty-state guidance and a simple date toolbar for quick context

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923fb88a71083219629a726ce0898fb)